### PR TITLE
added source/target keys to relationships

### DIFF
--- a/orm-db-model.html
+++ b/orm-db-model.html
@@ -93,9 +93,10 @@
             "align-items":"center"
         });
         let inputRows = $('<div></div>',{style:"flex-grow:1"}).appendTo(container);
-        let column1 = $('<div></div>',{style:"display: inline-block;width:25%;"}).appendTo(inputRows);
-        let column2 = $('<div/>',{style:"display: inline-block;width:35%;padding-left:15px"}).appendTo(inputRows);
-        let column3 = $('<div/>',{style:"display: inline-block;width:35%;padding-left:15px"}).appendTo(inputRows);
+        let column1 = $('<div></div>',{style:"display: inline-block;width:20%;"}).appendTo(inputRows);
+        let column2 = $('<div/>',{style:"display: inline-block;width:20%;padding-left:15px"}).appendTo(inputRows);
+        let column3 = $('<div/>',{style:"display: inline-block;width:20%;padding-left:15px"}).appendTo(inputRows);
+        let column4 = $('<div/>',{style:"display: inline-block;width:20%;padding-left:15px"}).appendTo(inputRows);
         
         let selectAssociation = $('<select/>',{class:"node-input-association-value",style:"width:100%; text-align: center;"}).appendTo(column1);
         selectAssociation.append($("<option></option>").val('HasOne').text('HasOne'));
@@ -115,7 +116,12 @@
         let inputForeignKey = $('<input type="text" class="node-input-foreignkey-value" style="width:100%;"/>').appendTo(column3);
         if(data.foreignKey)
             inputForeignKey.val(data.foreignKey);
-    }
+
+        let inputTargetKey = $('<input type="text" class="node-input-targetKey-value" style="width:100%;"/>').appendTo(column4);
+        if(data.targetKey)
+            inputTargetKey.val(data.targetKey);
+
+        }
 
     function getRelationships() {   
         let relationships = []
@@ -125,7 +131,9 @@
                 const model = $(this).find(".node-input-model-value").val()
                 const association = $(this).find(".node-input-association-value").val()
                 const foreignKey = $(this).find(".node-input-foreignkey-value").val()
-                relationships.push({model, association, foreignKey})
+                const targetKey = $(this).find(".node-input-targetKey-value").val()
+               
+                relationships.push({model, association, foreignKey,targetKey})
             });
         } catch{}        
         return relationships 
@@ -170,7 +178,9 @@
 
             $("#node-input-relationship").css('min-height','160px').editableList({
                 removable: true,
-                header: $('<div style="display:flex"></div>').append($.parseHTML("<div style='width:25%;display: inline; padding-left:15px'>Association</div><div style='width:35%;display: inline;'>Model</div><div style='width:35%;display: inline;'>Foreign Key</div>")),
+                header: $('<div style="display:flex"></div>').append(
+                    $.parseHTML("<div style='width:30%;display: inline; padding-left:15px'>Association</div><div style='width:20%;display: inline;'>Model</div><div style='width:20%;display: inline;'>Foreign Key</div><div style='width:20%;display: inline;'>Source/Target Key</div>")
+                ),
                 addItem: function(container, index, data) {
                     insertRowRelationship(container, data, configModels)
                 }

--- a/orm-db.js
+++ b/orm-db.js
@@ -385,14 +385,25 @@ function createRelationship() {
             
             models[j].relationship.forEach(r=>{
                 let options = r.foreignKey ? { foreignKey: r.foreignKey, timestamps: false} : {timestamps: false}
+                
                 switch (r.association) {
                     case 'HasOne':{
                         sequelize[i].instance.models[j].hasOne(sequelize[i].instance.models[r.model], options)
                     }break;
                     case 'BelongsTo':{
+
+                        if (r.targetKey) {
+                            options.targetKey = r.targetKey;
+                        }
+
                         sequelize[i].instance.models[j].belongsTo(sequelize[i].instance.models[r.model], options)
                     }break;
                     case 'HasMany':{
+
+                        if (r.targetKey) {
+                            options.sourceKey = r.targetKey;
+                        }
+                        console.log(options)
                         sequelize[i].instance.models[j].hasMany(sequelize[i].instance.models[r.model], options)
                     }break;
                     case 'BelongsToMany':{                    


### PR DESCRIPTION
Sequelize supports for  "belongs to" relationships a target key, or for "has many" a source key. 
This means you can specify a field other than the primary key of the table to use in a relationship.
